### PR TITLE
Update Go version to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UCLALibrary/festerize-go
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.1


### PR DESCRIPTION
This PR updates the Go version in the go.mod file to the latest available version.