### PR TITLE
Update Go version to 1.25.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UCLALibrary/festerize-go
 
-go 1.25.2
+go 1.25.3
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3


### PR DESCRIPTION
This PR updates the Go version in the go.mod file to the latest available version.